### PR TITLE
New feature to compare to ontologies with each other

### DIFF
--- a/examples/compare_ontologies.rs
+++ b/examples/compare_ontologies.rs
@@ -1,0 +1,156 @@
+use std::path::Path;
+use hpo::Ontology;
+
+fn main() {
+    let mut args = std::env::args();
+
+    if args.len() != 3 {
+        panic!("Usage: ./compare_ontologies /path/to/old/ontology /path/to/new/ontology");
+    }
+    let arg_old = args.nth(1).unwrap();
+    let arg_new = args.next().unwrap();
+
+    let path_old = Path::new(&arg_old);
+    let path_new = Path::new(&arg_new);
+
+    let lhs = match path_old.is_file() {
+        true => Ontology::from_binary(path_old).unwrap(),
+        false => Ontology::from_standard(&path_old.to_string_lossy()).unwrap(),
+    };
+
+    let rhs = match path_new.is_file() {
+        true => Ontology::from_binary(path_new).unwrap(),
+        false => Ontology::from_standard(&path_new.to_string_lossy()).unwrap(),
+    };
+
+    let diffs = lhs.compare(&rhs);
+    println!("#Numbers\n{}", diffs);
+    println!("#Change\tID\tName");
+    for term in diffs.added_hpo_terms() {
+        println!("Added\t{}\t{}", term.id(), term.name());
+    }
+    for term in diffs.removed_hpo_terms() {
+        println!("Removed\t{}\t{}", term.id(), term.name());
+    }
+
+    for gene in diffs.added_genes() {
+        println!("Added\t{}\t{}", gene.id(), gene.name());
+    }
+
+    for gene in diffs.removed_genes() {
+        println!("Removed\t{}\t{}", gene.id(), gene.name());
+    }
+
+    for disease in diffs.added_omim_diseases() {
+        println!("Added\t{}\t{}", disease.id(), disease.name());
+    }
+
+    for disease in diffs.removed_omim_diseases() {
+        println!("Removed\t{}\t{}", disease.id(), disease.name());
+    }
+
+    println!("#Term Delta\tID\tOld Name:New Name\tAdded Parents\tRemoved Parents");
+    for term in diffs.changed_hpo_terms() {
+        print!("Delta\t{}", term.id());
+        if let Some(names) = term.changed_name() {
+            print!("\t{}:{}", names.0, names.1);
+        } else {
+            print!("\t.");
+        }
+        if let Some(added) = term.added_parents() {
+            print!(
+                "\t{}",
+                added
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        if let Some(removed) = term.removed_parents() {
+            print!(
+                "\t{}",
+                removed
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        println!();
+    }
+
+    println!("#Gene Delta\tID\tOld Name:New Name\tAdded Parents\tRemoved Parents");
+    for term in diffs.changed_genes() {
+        print!("Delta\t{}", term.id());
+        if let Some(names) = term.changed_name() {
+            print!("\t{}:{}", names.0, names.1);
+        } else {
+            print!("\t.");
+        }
+        if let Some(added) = term.added_terms() {
+            print!(
+                "\t{}",
+                added
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        if let Some(removed) = term.removed_terms() {
+            print!(
+                "\t{}",
+                removed
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        println!();
+    }
+
+    println!("#Disease Delta\tID\tOld Name:New Name\tAdded Parents\tRemoved Parents");
+    for term in diffs.changed_omim_diseases() {
+        print!("Delta\t{}", term.id());
+        if let Some(names) = term.changed_name() {
+            print!("\t{}:{}", names.0, names.1);
+        } else {
+            print!("\t.");
+        }
+        if let Some(added) = term.added_terms() {
+            print!(
+                "\t{}",
+                added
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        if let Some(removed) = term.removed_terms() {
+            print!(
+                "\t{}",
+                removed
+                    .iter()
+                    .map(|tid| tid.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",")
+            );
+        } else {
+            print!("\t.");
+        }
+        println!();
+    }
+}

--- a/src/annotations/gene.rs
+++ b/src/annotations/gene.rs
@@ -61,7 +61,7 @@ impl From<u32> for GeneId {
 
 impl Display for GeneId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Gene NCBI:{}", self.inner)
+        write!(f, "NCBI-GeneID:{}", self.inner)
     }
 }
 

--- a/src/ontology/comparison.rs
+++ b/src/ontology/comparison.rs
@@ -1,0 +1,328 @@
+use std::collections::HashSet;
+use std::fmt::Display;
+
+use crate::annotations::{Gene, OmimDisease};
+use crate::term::HpoGroup;
+use crate::{HpoTerm, HpoTermId, Ontology};
+
+#[derive(Debug)]
+/// Compares the content of two Ontologies
+///
+/// This can be used when a new HPO masterdata release is available
+/// to check what is changed between the previous and new one.
+pub struct OntologyComparison<'a> {
+    lhs: &'a Ontology,
+    rhs: &'a Ontology,
+}
+
+impl<'a> Display for OntologyComparison<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Terms\t{}\t{}\nGenes\t{}\t{}\nOmim Diseases\t{}\t{}",
+            self.lhs.len(),
+            self.rhs.len(),
+            self.lhs.genes().count(),
+            self.rhs.genes().count(),
+            self.lhs.omim_diseases().count(),
+            self.rhs.omim_diseases().count()
+        )
+    }
+}
+
+impl<'a> OntologyComparison<'a> {
+    /// Constructs a new [`OntologyComparison`] from two [`Ontology`]
+    /// The first argument, `lhs`, is considered the `old` or `base` Ontology,
+    /// while the second argument, `rhs` is considered the `new` or `changed` one.
+    pub fn new(lhs: &'a Ontology, rhs: &'a Ontology) -> Self {
+        Self { lhs, rhs }
+    }
+
+    /// Returns all [`HpoTerm`]s that are exclusively in the `new` Ontology
+    pub fn added_hpo_terms(&self) -> Vec<HpoTerm<'a>> {
+        self.rhs
+            .hpos()
+            .filter(|term| self.lhs.hpo(term.id()).is_none())
+            .collect()
+    }
+
+    /// Returns all [`HpoTerm`]s that are exclusively in the `old` Ontology
+    pub fn removed_hpo_terms(&self) -> Vec<HpoTerm<'a>> {
+        self.lhs
+            .hpos()
+            .filter(|term| self.rhs.hpo(term.id()).is_none())
+            .collect()
+    }
+
+    /// Returns an [`HpoTermDelta`] struct for every HPO term that is different
+    /// between the `old` and `new` Ontology.
+    ///
+    /// Differences are defined as either:
+    /// - Changed name
+    /// - Changed direct parents
+    pub fn changed_hpo_terms(&self) -> Vec<HpoTermDelta> {
+        self.lhs
+            .hpos()
+            .filter_map(|term| {
+                if let Some(rhs) = self.rhs.hpo(term.id()) {
+                    HpoTermDelta::new(term, rhs)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Returns all [`Gene`]s that are exclusively in the `new` Ontology
+    pub fn added_genes(&self) -> Vec<&Gene> {
+        self.rhs
+            .genes()
+            .filter(|gene| self.lhs.gene(gene.id()).is_none())
+            .collect()
+    }
+
+    /// Returns all [`Gene`]s that are exclusively in the `old` Ontology
+    pub fn removed_genes(&self) -> Vec<&Gene> {
+        self.lhs
+            .genes()
+            .filter(|gene| self.rhs.gene(gene.id()).is_none())
+            .collect()
+    }
+
+    /// Returns an [`AnnotationDelta`] struct for every [`Gene`] that is different
+    /// between the `old` and `new` Ontology.
+    ///
+    /// Differences are defined as either:
+    /// - Changed name
+    /// - Changed direct associated `HpoTerm`s
+    pub fn changed_genes(&self) -> Vec<AnnotationDelta> {
+        self.lhs
+            .genes()
+            .filter_map(|gene| {
+                if let Some(rhs) = self.rhs.gene(gene.id()) {
+                    AnnotationDelta::gene(gene, rhs)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Returns all [`OmimDisease`]s that are exclusively in the `new` Ontology
+    pub fn added_omim_diseases(&self) -> Vec<&OmimDisease> {
+        self.rhs
+            .omim_diseases()
+            .filter(|disease| self.lhs.omim_disease(disease.id()).is_none())
+            .collect()
+    }
+
+    /// Returns all [`OmimDisease`]s that are exclusively in the `old` Ontology
+    pub fn removed_omim_diseases(&self) -> Vec<&OmimDisease> {
+        self.lhs
+            .omim_diseases()
+            .filter(|disease| self.rhs.omim_disease(disease.id()).is_none())
+            .collect()
+    }
+
+    /// Returns an [`AnnotationDelta`] struct for every [`OmimDisease`] that is different
+    /// between the `old` and `new` Ontology.
+    ///
+    /// Differences are defined as either:
+    /// - Changed name
+    /// - Changed direct associated `HpoTerm`s
+    pub fn changed_omim_diseases(&self) -> Vec<AnnotationDelta> {
+        self.lhs
+            .omim_diseases()
+            .filter_map(|disease| {
+                if let Some(rhs) = self.rhs.omim_disease(disease.id()) {
+                    AnnotationDelta::disease(disease, rhs)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+/// Differences between two [`HpoTerm`]s
+pub struct HpoTermDelta {
+    term_id: HpoTermId,
+    changed_name: (String, String),
+    added_parents: Vec<HpoTermId>,
+    removed_parents: Vec<HpoTermId>,
+}
+
+impl HpoTermDelta {
+    /// Constructs a new [`HpoTermDelta`] by comparing two [`HpoTerm`]s
+    ///
+    /// Returns `None` if both are identical
+    pub fn new(lhs: HpoTerm, rhs: HpoTerm) -> Option<Self> {
+        let changed_name = (lhs.name().to_string(), rhs.name().to_string());
+
+        let lhs_parents: HashSet<HpoTermId> = lhs.parents().map(|t| t.id()).collect();
+        let rhs_parents: HashSet<HpoTermId> = rhs.parents().map(|t| t.id()).collect();
+
+        let removed_parents: Vec<HpoTermId> =
+            lhs_parents.difference(&rhs_parents).copied().collect();
+        let added_parents: Vec<HpoTermId> = rhs_parents.difference(&lhs_parents).copied().collect();
+
+        if changed_name.0 != changed_name.1
+            || !removed_parents.is_empty()
+            || !added_parents.is_empty()
+        {
+            let term_id = lhs.id();
+            Some(Self {
+                term_id,
+                changed_name,
+                added_parents,
+                removed_parents,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns all direct parent [`HpoTermId`]s of the `new` term that
+    /// are not parents of the `old` term
+    ///
+    /// Returns `None` if no such terms exist
+    pub fn added_parents(&self) -> Option<&Vec<HpoTermId>> {
+        if self.added_parents.is_empty() {
+            None
+        } else {
+            Some(&self.added_parents)
+        }
+    }
+
+    /// Returns all direct parent [`HpoTermId`]s of the `old` term that
+    /// are not parents of the `new` term
+    ///
+    /// Returns `None` if no such terms exist
+    pub fn removed_parents(&self) -> Option<&Vec<HpoTermId>> {
+        if self.removed_parents.is_empty() {
+            None
+        } else {
+            Some(&self.removed_parents)
+        }
+    }
+
+    /// Returns the `old` and `new` name if they are different
+    ///
+    /// Returns `None` if the name is unchanged
+    pub fn changed_name(&self) -> Option<&(String, String)> {
+        if self.changed_name.0 != self.changed_name.1 {
+            Some(&self.changed_name)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the [`HpoTermId`] of the term
+    pub fn id(&self) -> &HpoTermId {
+        &self.term_id
+    }
+}
+
+/// Differences between two [`Gene`]s or [`OmimDisease`]s
+pub struct AnnotationDelta {
+    id: String,
+    names: (String, String),
+    added_terms: Vec<HpoTermId>,
+    removed_terms: Vec<HpoTermId>,
+}
+
+impl<'a> AnnotationDelta {
+    /// Constructs a new [`AnnotationDelta`] by comparing two [`Gene`]s
+    ///
+    /// Returns `None` if both are identical
+    pub fn gene(lhs: &Gene, rhs: &Gene) -> Option<Self> {
+        let lhs_terms = lhs.hpo_terms();
+        let rhs_terms = rhs.hpo_terms();
+
+        let names = (lhs.name().to_string(), rhs.name().to_string());
+
+        Self::delta(lhs_terms, rhs_terms, names, lhs.id().to_string())
+    }
+
+    /// Constructs a new [`AnnotationDelta`] by comparing two [`OmimDisease`]s
+    ///
+    /// Returns `None` if both are identical
+    pub fn disease(lhs: &OmimDisease, rhs: &OmimDisease) -> Option<Self> {
+        let lhs_terms = lhs.hpo_terms();
+        let rhs_terms = rhs.hpo_terms();
+
+        let names = (lhs.name().to_string(), rhs.name().to_string());
+
+        Self::delta(lhs_terms, rhs_terms, names, lhs.id().to_string())
+    }
+
+    /// Calculates the difference between both items and constructs a new
+    /// `AnnotationDelta` struct or returns None
+    fn delta(
+        lhs_terms: &HpoGroup,
+        rhs_terms: &HpoGroup,
+        names: (String, String),
+        id: String,
+    ) -> Option<Self> {
+        let added_terms: Vec<HpoTermId> = rhs_terms
+            .iter()
+            .filter(|termid| !lhs_terms.contains(termid))
+            .collect();
+
+        let removed_terms: Vec<HpoTermId> = lhs_terms
+            .iter()
+            .filter(|termid| !rhs_terms.contains(termid))
+            .collect();
+
+        if !added_terms.is_empty() || !removed_terms.is_empty() || names.0 != names.1 {
+            Some(Self {
+                id,
+                names,
+                added_terms,
+                removed_terms,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Returns all directly linked [`HpoTermId`]s of the `new` annotation that
+    /// are not linked to the `old` anotation
+    ///
+    /// Returns `None` if no such terms exist
+    pub fn added_terms(&'a self) -> Option<&Vec<HpoTermId>> {
+        if self.added_terms.is_empty() {
+            None
+        } else {
+            Some(&self.added_terms)
+        }
+    }
+
+    /// Returns all directly linked [`HpoTermId`]s of the `old` annotation that
+    /// are not linked to the `new` anotation
+    ///
+    /// Returns `None` if no such terms exist
+    pub fn removed_terms(&'a self) -> Option<&Vec<HpoTermId>> {
+        if self.removed_terms.is_empty() {
+            None
+        } else {
+            Some(&self.removed_terms)
+        }
+    }
+
+    /// Returns the `old` and `new` name if they are different
+    ///
+    /// Returns `None` if the name is unchanged
+    pub fn changed_name(&self) -> Option<&(String, String)> {
+        if self.names.0 != self.names.1 {
+            Some(&self.names)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the `String`-formatted ID of the annotation
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -15,8 +15,11 @@ use crate::{HpoError, HpoTermId};
 
 use core::fmt::Debug;
 
+mod comparison;
 mod termarena;
 use termarena::Arena;
+use comparison::OntologyComparison;
+
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// `Ontology` is the main interface of the `hpo` crate and contains all data
@@ -361,6 +364,11 @@ impl Ontology {
         &self,
     ) -> std::collections::hash_map::Values<'_, OmimDiseaseId, OmimDisease> {
         self.omim_diseases.values()
+    }
+
+    /// Compares `self` to another `Ontology` to identify added/removed terms, genes and diseases
+    pub fn compare<'a>(&'a self, other: &'a Ontology) -> OntologyComparison {
+        OntologyComparison::new(self, other)
     }
 }
 


### PR DESCRIPTION
New feature:
- Method to compare two Ontologies to each other, list added/removed/changed terms, genes, diseases

Breaking changes:
- Format of `GeneId::to_string()` changed slightly