### PR TITLE
Hotfix/subontology

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpo"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Jonas Marcello <jonas.marcello@esbme.com>"]
 description = "Human Phenotype Ontology Similarity"

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -809,7 +809,10 @@ impl Ontology {
 
         let mut ont = Self::default();
         for &term in &terms {
-            ont.add_term(term.clone());
+            let mut copied_term = HpoTermInternal::new(term.name().to_string(), *term.id());
+            *copied_term.obsolete_mut() = term.obsolete();
+            *copied_term.replacement_mut() = term.replacement();
+            ont.add_term(copied_term);
         }
         for term in &terms {
             for parent in term.parents() {


### PR DESCRIPTION
Fixes a bug where the terms in a subontology contained all parents/children, causing subsequent iterations to crash.
This fixes ensures that only sub-ontology-relevant terms are included as parents/children for every term