### PR TITLE
Fixes #30 New JAX-HPO source format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpo"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Jonas Marcello <jonas.marcello@esbme.com>"]
 description = "Human Phenotype Ontology Similarity"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,7 +25,8 @@ pub(crate) mod phenotype_to_genes {
         let reader = BufReader::new(file);
         for line in reader.lines() {
             let line = line.unwrap();
-            if line.starts_with('#') {
+            // TODO: Check for the header outside of the `lines` iterator
+            if line.starts_with('#') || line.starts_with("hpo_id") {
                 continue;
             }
             let cols: Vec<&str> = line.trim().split('\t').collect();
@@ -63,6 +64,8 @@ pub(crate) mod phenotype_hpoa {
     }
 
     fn parse_line(line: &str) -> Option<Omim<'_>> {
+        // TODO (nice to have): Add check to skip `database_id` header row
+        // It is not strictly needed, because we're discarding non-OMIM rows
         if line.starts_with('#') {
             return None;
         }


### PR DESCRIPTION
This fixes #30:
A new source data format from JAX causes the Phenotype to Gene parser to fail. JAX-HPO changed the header row

from

`#Format: HPO-id<tab>HPO label<tab>entrez-gene-id<tab>entrez-gene-symbol<tab>Additional Info from G-D source<tab>G-D source<tab>disease-ID for link`

to
`hpo_id  hpo_name        ncbi_gene_id    gene_symbol`

The fix is working but not performance optimized and could be improved - if the parsing code becomes a bottleneck