### PR TITLE
Add categories for HPO Terms

### DIFF
--- a/examples/distance_to_term.rs
+++ b/examples/distance_to_term.rs
@@ -1,0 +1,44 @@
+//! Print the distance from one term to another
+
+use hpo::HpoTerm;
+use hpo::HpoTermId;
+use hpo::Ontology;
+
+/// Calculate the distance from Term to term for all combinations
+/// of terms within the ontology
+fn all_distances(ontology: &Ontology) {
+    for term1 in ontology.hpos() {
+        for term2 in ontology.hpos() {
+            print_distance(&term1, &term2)
+        }
+    }
+}
+
+/// Print the shortest distance from one term to another
+fn print_distance(term1: &HpoTerm, term2: &HpoTerm) {
+    if let Some(dist) = term1.distance_to_term(term2) {
+        println!("{}\t{}\t{}", term1.id(), term2.id(), dist);
+    }
+}
+
+fn main() {
+    let ontology = Ontology::from_standard("./example_data/").unwrap();
+
+    let mut args = std::env::args();
+    if args.len() == 3 {
+        let termid1 = HpoTermId::from(args.nth(1).unwrap());
+        let termid2 = HpoTermId::from(args.next().unwrap());
+        let term1 = ontology.hpo(termid1).unwrap();
+        let term2 = ontology.hpo(termid2).unwrap();
+        print_distance(&term1, &term2);
+        if let Some(path) = term1.path_to_term(&term2) {
+            for term in path {
+                println!("{}", term);
+            }
+        } else {
+            println!("No common ancestor");
+        }
+    } else {
+        all_distances(&ontology);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ const OBO_FILENAME: &str = "hp.obo";
 const GENE_FILENAME: &str = "phenotype_to_genes.txt";
 const DISEASE_FILENAME: &str = "phenotype.hpoa";
 
+/// The `HpoTermId` of `HP:0000118 | Phenotypic abnormality`
+pub const PHENOTYPE_ID: HpoTermId = HpoTermId::from_u32(118);
+
 #[derive(Error, Debug)]
 /// Main Error type for this crate
 pub enum HpoError {

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -634,7 +634,7 @@ impl Ontology {
     /// assert!(ontology.hpo(66666u32).is_none());
     /// ```
     pub fn hpo<I: Into<HpoTermId>>(&self, term_id: I) -> Option<HpoTerm> {
-        HpoTerm::try_new(self, term_id.into()).ok()
+        HpoTerm::try_new(self, term_id).ok()
     }
 
     /// Returns an Iterator of all [`HpoTerm`]s from the Ontology
@@ -947,7 +947,7 @@ impl Ontology {
     ///
     /// are present in the Ontology.
     pub fn set_default_categories(&mut self) -> HpoResult<()> {
-        let root = self.hpo(1u32.into()).ok_or(HpoError::DoesNotExist)?;
+        let root = self.hpo(1u32).ok_or(HpoError::DoesNotExist)?;
         let phenotypes = self
             .hpo(crate::PHENOTYPE_ID)
             .ok_or(HpoError::DoesNotExist)?;
@@ -997,7 +997,7 @@ impl Ontology {
     /// This method requires that the root term `HP:0000001 | All` is present.
     pub fn set_default_modifier(&mut self) -> HpoResult<()> {
         self.modifier = self
-            .hpo(1u32.into())
+            .hpo(1u32)
             .ok_or(HpoError::DoesNotExist)?
             .children_ids()
             .iter()

--- a/src/ontology/comparison.rs
+++ b/src/ontology/comparison.rs
@@ -193,7 +193,7 @@ impl HpoTermDelta {
             lhs_parents.difference(&rhs_parents).copied().collect();
         let added_parents: Vec<HpoTermId> = rhs_parents.difference(&lhs_parents).copied().collect();
 
-        let obsolete = (lhs.obsolete(), rhs.obsolete());
+        let obsolete = (lhs.is_obsolete(), rhs.is_obsolete());
         let replacement = (
             lhs.replaced_by().map(|t| t.id()),
             rhs.replaced_by().map(|t| t.id()),

--- a/src/set.rs
+++ b/src/set.rs
@@ -172,11 +172,76 @@ impl<'a> HpoSet<'a> {
         self.group.is_empty()
     }
 
+    /// Removes all modifier terms in-place
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hpo::{Ontology, HpoSet};
+    /// # use hpo::term::HpoGroup;
+    /// # fn method_that_returns_an_hposet<'a>(ontology: &'a Ontology) -> HpoSet<'a> {
+    /// # let mut hpos = HpoGroup::new();
+    /// # hpos.insert(707u32.into());
+    /// # hpos.insert(12639u32.into());
+    /// # hpos.insert(12638u32.into());
+    /// # hpos.insert(3581u32.into());
+    /// # hpos.insert(7u32.into());
+    /// # HpoSet::new(ontology, hpos)
+    /// # }
+    ///
+    /// let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
+    ///
+    /// let mut set: HpoSet = method_that_returns_an_hposet(&ontology);
+    /// assert_eq!(set.len(), 5);
+    ///
+    /// set.remove_modifier();
+    /// assert_eq!(set.len(), 3);
+    /// ```
+    pub fn remove_modifier(&mut self) {
+        let group: HpoGroup = self.iter().filter(|term| !term.is_modifier()).collect();
+        self.group = group;
+    }
+
     /// Returns a new set without modifier terms
     ///
-    /// This is not yet implemented
-    pub fn remove_modifier(&mut self) {
-        unimplemented!()
+    /// # Examples
+    ///
+    /// ```
+    /// use hpo::{Ontology, HpoSet};
+    /// # use hpo::term::HpoGroup;
+    /// # fn method_that_returns_an_hposet<'a>(ontology: &'a Ontology) -> HpoSet<'a> {
+    /// # let mut hpos = HpoGroup::new();
+    /// # hpos.insert(707u32.into());
+    /// # hpos.insert(12639u32.into());
+    /// # hpos.insert(12638u32.into());
+    /// # hpos.insert(3581u32.into());
+    /// # hpos.insert(7u32.into());
+    /// # HpoSet::new(ontology, hpos)
+    /// # }
+    ///
+    /// let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
+    ///
+    /// let set_1: HpoSet = method_that_returns_an_hposet(&ontology);
+    /// assert_eq!(set_1.len(), 5);
+    ///
+    /// let set_2 = set_1.without_modifier();
+    /// assert_eq!(set_2.len(), 3);
+    ///
+    /// for term in set_1.iter() {
+    ///     if !set_2.contains(&term.id()) {
+    ///         println!("Modifier: {} | {}", term.id(), term.name());
+    ///     }
+    /// }
+    /// // "HP:0000007 | Autosomal recessive inheritance"
+    /// // "HP:0003581 | Adult onset"
+    /// ```
+    pub fn without_modifier(&self) -> Self {
+        let group: HpoGroup = self.iter().filter(|term| !term.is_modifier()).collect();
+        Self {
+            ontology: self.ontology,
+            group,
+        }
     }
 
     /// Removes all obsolete terms in-place

--- a/src/set.rs
+++ b/src/set.rs
@@ -184,11 +184,11 @@ impl<'a> HpoSet<'a> {
     /// # use hpo::term::HpoGroup;
     /// # fn method_that_returns_an_hposet<'a>(ontology: &'a Ontology) -> HpoSet<'a> {
     /// # let mut hpos = HpoGroup::new();
-    /// # hpos.insert(707u32.into());
-    /// # hpos.insert(12639u32.into());
-    /// # hpos.insert(12638u32.into());
-    /// # hpos.insert(3581u32.into());
-    /// # hpos.insert(7u32.into());
+    /// # hpos.insert(707u32);
+    /// # hpos.insert(12639u32);
+    /// # hpos.insert(12638u32);
+    /// # hpos.insert(3581u32);
+    /// # hpos.insert(7u32);
     /// # HpoSet::new(ontology, hpos)
     /// # }
     ///
@@ -214,11 +214,11 @@ impl<'a> HpoSet<'a> {
     /// # use hpo::term::HpoGroup;
     /// # fn method_that_returns_an_hposet<'a>(ontology: &'a Ontology) -> HpoSet<'a> {
     /// # let mut hpos = HpoGroup::new();
-    /// # hpos.insert(707u32.into());
-    /// # hpos.insert(12639u32.into());
-    /// # hpos.insert(12638u32.into());
-    /// # hpos.insert(3581u32.into());
-    /// # hpos.insert(7u32.into());
+    /// # hpos.insert(707u32);
+    /// # hpos.insert(12639u32);
+    /// # hpos.insert(12638u32);
+    /// # hpos.insert(3581u32);
+    /// # hpos.insert(7u32);
     /// # HpoSet::new(ontology, hpos)
     /// # }
     ///
@@ -525,12 +525,12 @@ impl<'a> HpoSet<'a> {
     /// let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
     ///
     /// let mut hpos = HpoGroup::new();
-    /// hpos.insert(12285u32.into());  // Abnormal hypothalamus physiology
-    /// hpos.insert(12639u32.into());  // Abnormal nervous system morphology
-    /// hpos.insert(12638u32.into());  // Abnormal nervous system physiology
-    /// hpos.insert(12648u32.into());  // Decreased inflammatory response
-    /// hpos.insert(3581u32.into());  // Adult onset
-    /// hpos.insert(7u32.into());  // Autosomal recessive inheritance
+    /// hpos.insert(12285u32);  // Abnormal hypothalamus physiology
+    /// hpos.insert(12639u32);  // Abnormal nervous system morphology
+    /// hpos.insert(12638u32);  // Abnormal nervous system physiology
+    /// hpos.insert(12648u32);  // Decreased inflammatory response
+    /// hpos.insert(3581u32);  // Adult onset
+    /// hpos.insert(7u32);  // Autosomal recessive inheritance
     ///
     /// let set: HpoSet = HpoSet::new(&ontology, hpos);
     /// let cats = set.categories();

--- a/src/term/hpoterm.rs
+++ b/src/term/hpoterm.rs
@@ -907,8 +907,8 @@ impl<'a> HpoTerm<'a> {
     ///
     /// let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
     ///
-    /// let term1 = ontology.hpo(25454u32.into()).unwrap();
-    /// let term3 = ontology.hpo(12639u32.into()).unwrap();
+    /// let term1 = ontology.hpo(25454u32).unwrap();
+    /// let term3 = ontology.hpo(12639u32).unwrap();
     ///
     /// assert_eq!(
     ///     term1.path_to_term(&term3).unwrap(),
@@ -1002,9 +1002,9 @@ impl<'a> HpoTerm<'a> {
     ///
     /// let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
     ///
-    /// let mendelian_inheritance = ontology.hpo(34345u32.into()).unwrap();
-    /// let adult_onset = ontology.hpo(3581u32.into()).unwrap();
-    /// let abnormal_forebrain_morphology = ontology.hpo(100547u32.into()).unwrap();
+    /// let mendelian_inheritance = ontology.hpo(34345u32).unwrap();
+    /// let adult_onset = ontology.hpo(3581u32).unwrap();
+    /// let abnormal_forebrain_morphology = ontology.hpo(100547u32).unwrap();
     ///
     /// assert!(mendelian_inheritance.is_modifier());
     /// assert!(adult_onset.is_modifier());
@@ -1097,9 +1097,9 @@ mod test_categories {
     fn test_modifier() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
 
-        let mendelian_inheritance = ontology.hpo(34345u32.into()).unwrap();
-        let adult_onset = ontology.hpo(3581u32.into()).unwrap();
-        let abnormal_forebrain_morphology = ontology.hpo(100_547u32.into()).unwrap();
+        let mendelian_inheritance = ontology.hpo(34345u32).unwrap();
+        let adult_onset = ontology.hpo(3581u32).unwrap();
+        let abnormal_forebrain_morphology = ontology.hpo(100_547u32).unwrap();
 
         assert!(mendelian_inheritance.is_modifier());
         assert!(adult_onset.is_modifier());
@@ -1110,8 +1110,8 @@ mod test_categories {
     fn test_modifier_is_self() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
 
-        let inheritance = ontology.hpo(HpoTermId::from_u32(5)).unwrap();
-        let nervous_system = ontology.hpo(HpoTermId::from_u32(707)).unwrap();
+        let inheritance = ontology.hpo(5u32).unwrap();
+        let nervous_system = ontology.hpo(707u32).unwrap();
 
         assert!(inheritance.is_modifier());
         assert!(!nervous_system.is_modifier());
@@ -1125,8 +1125,8 @@ mod test_path_to_term {
     #[test]
     fn normal() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
-        let term1 = ontology.hpo(25454u32.into()).unwrap();
-        let term2 = ontology.hpo(12639u32.into()).unwrap();
+        let term1 = ontology.hpo(25454u32).unwrap();
+        let term2 = ontology.hpo(12639u32).unwrap();
 
         assert_eq!(
             term1.path_to_term(&term2).unwrap(),
@@ -1152,8 +1152,8 @@ mod test_path_to_term {
     #[test]
     fn same_term() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
-        let term1 = ontology.hpo(12639u32.into()).unwrap();
-        let term2 = ontology.hpo(12639u32.into()).unwrap();
+        let term1 = ontology.hpo(12639u32).unwrap();
+        let term2 = ontology.hpo(12639u32).unwrap();
 
         assert_eq!(
             term1.path_to_term(&term2).unwrap(),
@@ -1164,8 +1164,8 @@ mod test_path_to_term {
     #[test]
     fn parent_term() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
-        let term1 = ontology.hpo(12639u32.into()).unwrap();
-        let term2 = ontology.hpo(707u32.into()).unwrap();
+        let term1 = ontology.hpo(12639u32).unwrap();
+        let term2 = ontology.hpo(707u32).unwrap();
 
         assert_eq!(
             term1.path_to_term(&term2).unwrap(),
@@ -1176,8 +1176,8 @@ mod test_path_to_term {
     #[test]
     fn child_term() {
         let ontology = Ontology::from_binary("tests/example.hpo").unwrap();
-        let term1 = ontology.hpo(707u32.into()).unwrap();
-        let term2 = ontology.hpo(12639u32.into()).unwrap();
+        let term1 = ontology.hpo(707u32).unwrap();
+        let term2 = ontology.hpo(12639u32).unwrap();
 
         assert_eq!(
             term1.path_to_term(&term2).unwrap(),

--- a/src/term/hpotermid.rs
+++ b/src/term/hpotermid.rs
@@ -29,6 +29,20 @@ impl HpoTermId {
             .try_into()
             .expect("hpo can only run on systems with at least 32 bit architecture")
     }
+
+    /// Creates a new `HpoTermId` from a `u32` integer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use hpo::HpoTermId;
+    ///
+    /// let a = HpoTermId::from_u32(118);
+    /// assert_eq!(a.to_usize(), 118usize);
+    /// ```
+    pub const fn from_u32(inner: u32) -> Self {
+        HpoTermId { inner }
+    }
 }
 
 impl AnnotationId for HpoTermId {

--- a/src/term/internal.rs
+++ b/src/term/internal.rs
@@ -262,7 +262,7 @@ impl TryFrom<Bytes<'_>> for HpoTermInternal {
 impl<'a> From<&HpoTerm<'a>> for HpoTermInternal {
     fn from(term: &HpoTerm) -> Self {
         let mut internal = Self::new(term.name().to_string(), term.id());
-        *internal.obsolete_mut() = term.obsolete();
+        *internal.obsolete_mut() = term.is_obsolete();
         *internal.replacement_mut() = term.replaced_by().map(|repl| repl.id());
         internal
     }


### PR DESCRIPTION
HPO terms can be categorized by their top-level phenotype parent and can be classified as modifier term