### PR TITLE
Use SmallVec for HpoGroup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1.0.37"
 aquamarine = "0.1" # used in Docs
 statrs = "0.16.0"
 tracing = "0.1.37"
+smallvec = "1.10.0"
 
 [dev-dependencies]
 rayon = "1.6.0"

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ The below benchmarks were run non scientificially and your mileage may vary. I u
 
 | Benchmark | `PyHPO` | `hpo` (single-threaded) | `hpo` (multi-threaded) |
 | --------- | ----- | --- | --- |
-| Read and Parse Ontology | 6.4 s | 0.25 s | 0.25 s |
-| Similarity of 17,245 x 1,000 terms | 98.5 s | 3.9 s | 1.0 s |
-| Similarity of GBA1 to all Diseases | 380 s | 18.2 s | 3.9 s |
-| Disease enrichment in all Genes | 11.8 s | 0.5 s | 0.3 s |
-| Common ancestors of 17,245 x 10,000 terms | 225.2 s | 11.1 | 2.5 |
+| Read and Parse Ontology | 6.4 s | 0.22 s | 0.22 s |
+| Similarity of 17,245 x 1,000 terms | 98.5 s | 4.6 s | 1.0 s |
+| Similarity of GBA1 to all Diseases | 380 s | 15.8 s | 3.0 s |
+| Disease enrichment in all Genes | 11.8 s | 0.4 s | 0.3 s |
+| Common ancestors of 17,245 x 10,000 terms | 225.2 s | 10.5 | 2.1 |
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use set::HpoSet;
 pub use term::{HpoTerm, HpoTermId};
 
 const DEFAULT_NUM_PARENTS: usize = 10;
-const DEFAULT_NUM_ALL_PARENTS: usize = 50;
+const DEFAULT_NUM_ALL_PARENTS: usize = 30;
 const DEFAULT_NUM_GENES: usize = 50;
 const DEFAULT_NUM_OMIM: usize = 20;
 const MAX_HPO_ID_INTEGER: usize = 10_000_000;

--- a/src/term/group.rs
+++ b/src/term/group.rs
@@ -15,7 +15,7 @@ use crate::{HpoTerm, HpoTermId, Ontology};
 /// This group is used e.g. for having a set of parent or child HPO Terms
 #[derive(Debug, Default, Clone)]
 pub struct HpoGroup {
-    ids: SmallVec<[HpoTermId; 30]>,
+    ids: SmallVec<[HpoTermId; crate::DEFAULT_NUM_ALL_PARENTS]>,
 }
 
 impl HpoGroup {

--- a/src/term/group.rs
+++ b/src/term/group.rs
@@ -3,6 +3,8 @@ use crate::annotations::AnnotationId;
 use std::collections::HashSet;
 use std::ops::{Add, BitAnd, BitOr};
 
+use smallvec::SmallVec;
+
 use crate::term;
 use crate::{HpoTerm, HpoTermId, Ontology};
 
@@ -13,7 +15,7 @@ use crate::{HpoTerm, HpoTermId, Ontology};
 /// This group is used e.g. for having a set of parent or child HPO Terms
 #[derive(Debug, Default, Clone)]
 pub struct HpoGroup {
-    ids: Vec<HpoTermId>,
+    ids: SmallVec<[HpoTermId; 30]>,
 }
 
 impl HpoGroup {
@@ -25,7 +27,7 @@ impl HpoGroup {
     /// Constructs a new, empty [`HpoGroup`] with the given capacity
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            ids: Vec::with_capacity(capacity),
+            ids: SmallVec::with_capacity(capacity),
         }
     }
 
@@ -244,7 +246,9 @@ impl BitOr<HpoTermId> for &HpoGroup {
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn bitor(self, rhs: HpoTermId) -> HpoGroup {
         let mut group = HpoGroup::with_capacity(self.len() + 1);
-        group.ids.extend(&self.ids);
+        for id in &self.ids {
+            group.ids.push(*id);
+        }
         group.insert(rhs);
         group
     }
@@ -254,7 +258,9 @@ impl Add<HpoTermId> for &HpoGroup {
     type Output = HpoGroup;
     fn add(self, rhs: HpoTermId) -> Self::Output {
         let mut group = HpoGroup::with_capacity(self.len() + 1);
-        group.ids.extend(&self.ids);
+        for id in &self.ids {
+            group.ids.push(*id);
+        }
         group.insert(rhs);
         group
     }
@@ -396,9 +402,9 @@ mod tests {
         let expected: Vec<HpoTermId> = vec![1u32.into(), 2u32.into(), 3u32.into(), 4u32.into()];
 
         let result = (&group1).bitor(&group2);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
         let result = group2.bitor(&group1);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
     }
 
     #[test]
@@ -422,9 +428,9 @@ mod tests {
             5u32.into(),
         ];
         let result = (&group1).bitor(&group2);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
         let result = (&group2).bitor(&group1);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
     }
 
     #[test]
@@ -440,9 +446,9 @@ mod tests {
 
         let expected: Vec<HpoTermId> = vec![1u32.into(), 2u32.into(), 3u32.into(), 4u32.into()];
         let result = (&group1).bitor(&group2);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
         let result = (&group2).bitor(&group1);
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
     }
 
     #[test]
@@ -457,9 +463,9 @@ mod tests {
 
         let expected: Vec<HpoTermId> = vec![1u32.into(), 2u32.into(), 3u32.into(), 4u32.into()];
         let result_1 = (&group1).bitor(&group2);
-        assert_eq!(result_1.ids, expected);
+        assert_eq!(result_1.ids.to_vec(), expected);
         let result_2 = group2.bitor(&group1);
-        assert_eq!(result_2.ids, expected);
+        assert_eq!(result_2.ids.to_vec(), expected);
     }
 
     #[test]
@@ -477,7 +483,7 @@ mod tests {
 
         let result = &group1 & &group2;
         let expected: Vec<HpoTermId> = vec![1u32.into(), 2u32.into()];
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
     }
 
     #[test]
@@ -497,6 +503,6 @@ mod tests {
 
         let result = &group1 & &group2;
         let expected: Vec<HpoTermId> = vec![2u32.into(), 7u32.into()];
-        assert_eq!(result.ids, expected);
+        assert_eq!(result.ids.to_vec(), expected);
     }
 }


### PR DESCRIPTION
Switch from `Vec` to `SmallVec` for `HpoGroup` structs used to store parent and child terms of HPOs. Most terms have very few parents, so having a stack-allocated SmallVec improves performance.