### PR TITLE
Public use of matrix::Matrix in lib.rs (#38)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod similarity;
 pub mod stats;
 pub mod term;
 
+pub use matrix::Matrix;
 pub use ontology::comparison;
 pub use ontology::Ontology;
 pub use set::HpoSet;


### PR DESCRIPTION
Here is the patch but please wait with merging - I still need to check "client" code.