### PR TITLE
Change Gene - Term associations

### DIFF
--- a/examples/compare_ontologies.rs
+++ b/examples/compare_ontologies.rs
@@ -21,7 +21,7 @@ fn ontology2(path_arg: &str) -> Ontology {
 
     match path.is_file() {
         true => Ontology::from_binary(path).unwrap(),
-        false => Ontology::from_genes_to_phenotypes(&path.to_string_lossy()).unwrap(),
+        false => Ontology::from_standard_transitive(&path.to_string_lossy()).unwrap(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ const MAX_HPO_ID_INTEGER: usize = 10_000_000;
 
 const OBO_FILENAME: &str = "hp.obo";
 const GENE_FILENAME: &str = "phenotype_to_genes.txt";
+const GENE_TO_PHENO_FILENAME: &str = "genes_to_phenotype.txt";
 const DISEASE_FILENAME: &str = "phenotype.hpoa";
 
 /// The `HpoTermId` of `HP:0000118 | Phenotypic abnormality`

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -72,7 +72,8 @@ use termarena::Arena;
 ///     Then use [`Ontology::from_standard`] to load the data.
 ///     You need the following files:
 ///     - `phenotype.hpoa` (Required to connect [`OmimDisease`]s to [`HpoTerm`]s)
-///     - `phenotype_to_genes.txt` (Required to connect [`Gene`]s to [`HpoTerm`]s)
+///     - `genes_to_phenotype.txt` (Required to connect [`Gene`]s to [`HpoTerm`]s)
+///         - alternatively: `phenotype_to_genes.txt` (use [`Ontology::from_standard_transitive`])
 ///     - `hp.obo` (Required for [`HpoTerm`]s and their connection to each other)
 /// 2. Load the ontology from a binary build using [`Ontology::from_binary`].
 ///
@@ -111,6 +112,15 @@ use termarena::Arena;
 /// Terms and [`crate::annotations`] ([`Gene`]s, [`OmimDisease`]s) have a many-to-many relationship. The
 /// [`Ontology`] does not contain a direct relationship between genes and diseases. This relation
 /// is only present indirectly via the connected [`HpoTerm`]s.
+///
+/// # Transivity of relations
+///
+/// **New in 0.9.0**
+///
+/// During the construction of the Ontology, every [`HpoTerm`] inherits all gene and disease
+/// association of its child terms.
+/// But [`Gene`]s and [`OmimDisease`]s will only contain links to *direct* [`HpoTerm`]s. The annotations
+/// are not transitiv.
 ///
 /// ```mermaid
 /// erDiagram
@@ -368,6 +378,15 @@ impl Ontology {
     /// - [`Ontology::add_gene`] failed
     /// - [`Ontology::add_omim_disease`] failed
     ///
+    ///
+    /// # Note
+    ///
+    /// Since version `0.9.0` this method will not load genes transitively. That means
+    /// only directly linked [`HpoTerm`]s are connected to each gene. However, every
+    /// [`HpoTerm`] will still inherit all gene and disease associations from its children.
+    /// See [this discussion](https://github.com/anergictcell/hpo/issues/44) for a more detailed
+    /// explanation
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -390,9 +409,9 @@ impl Ontology {
         let mut ont = Ontology::default();
         let path = Path::new(folder);
         let obo = path.join(crate::OBO_FILENAME);
-        let gene = path.join(crate::GENE_FILENAME);
+        let gene = path.join(crate::GENE_TO_PHENO_FILENAME);
         let disease = path.join(crate::DISEASE_FILENAME);
-        parser::load_from_standard_files(&obo, &gene, &disease, &mut ont)?;
+        parser::load_from_jax_files(&obo, &gene, &disease, &mut ont)?;
         ont.calculate_information_content()?;
         ont.set_default_categories()?;
         ont.set_default_modifier()?;
@@ -420,7 +439,7 @@ impl Ontology {
     /// # Note
     ///
     /// This method has one difference to [`Ontology::from_standard`] in that every [`Gene`]
-    /// only contains directly linked [`HpoTerm`] and not all inherited ones.
+    /// contains directly linked [`HpoTerm`] and all their ancestor terms.
     /// See [this discussion](https://github.com/anergictcell/hpo/issues/44) for a more detailed
     /// explanation
     ///
@@ -430,7 +449,7 @@ impl Ontology {
     /// use hpo::Ontology;
     /// use hpo::HpoTermId;
     ///
-    /// let ontology = Ontology::genes_to_phenotypes("/path/to/jax_hpo_data/").unwrap();
+    /// let ontology = Ontology::from_standard_transitive("/path/to/jax_hpo_data/").unwrap();
     ///
     /// assert!(ontology.len() == 26);
     ///
@@ -442,13 +461,13 @@ impl Ontology {
     /// assert_eq!(root_term.name(), "All");
     /// ```
     ///
-    pub fn from_genes_to_phenotypes(folder: &str) -> HpoResult<Self> {
+    pub fn from_standard_transitive(folder: &str) -> HpoResult<Self> {
         let mut ont = Ontology::default();
         let path = Path::new(folder);
         let obo = path.join(crate::OBO_FILENAME);
-        let gene = path.join(crate::GENE_TO_PHENO_FILENAME);
+        let gene = path.join(crate::GENE_FILENAME);
         let disease = path.join(crate::DISEASE_FILENAME);
-        parser::load_from_standard_no_transitive_genes(&obo, &gene, &disease, &mut ont)?;
+        parser::load_from_jax_files_with_transivitve_genes(&obo, &gene, &disease, &mut ont)?;
         ont.calculate_information_content()?;
         ont.set_default_categories()?;
         ont.set_default_modifier()?;

--- a/src/ontology/comparison.rs
+++ b/src/ontology/comparison.rs
@@ -286,6 +286,7 @@ impl HpoTermDelta {
 pub struct AnnotationDelta {
     id: String,
     names: (String, String),
+    n_terms: (usize, usize),
     added_terms: Vec<HpoTermId>,
     removed_terms: Vec<HpoTermId>,
 }
@@ -337,6 +338,7 @@ impl<'a> AnnotationDelta {
             Some(Self {
                 id,
                 names,
+                n_terms: (lhs_terms.len(), rhs_terms.len()),
                 added_terms,
                 removed_terms,
             })
@@ -383,5 +385,10 @@ impl<'a> AnnotationDelta {
     /// Returns the `String`-formatted ID of the annotation
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    /// Returns the number of terms linked to `old` and `new`
+    pub fn n_terms(&self) -> (usize, usize) {
+        self.n_terms
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,6 +8,41 @@ pub(crate) mod binary;
 /// Module to parse `hp.obo` file
 pub(crate) mod hp_obo;
 
+/// Module to parse HPO - `Gene` associations from `genes_to_phenotype.txt` file
+pub(crate) mod genes_to_phenotype {
+    use crate::parser::Path;
+    use crate::HpoResult;
+    use std::fs::File;
+    use std::io::BufRead;
+    use std::io::BufReader;
+
+    use crate::HpoTermId;
+    use crate::Ontology;
+
+    /// Quick and dirty parser for development and debugging
+    pub fn parse<P: AsRef<Path>>(file: P, ontology: &mut Ontology) -> HpoResult<()> {
+        let file = File::open(file).unwrap();
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let line = line.unwrap();
+            // TODO: Check for the header outside of the `lines` iterator
+            if line.starts_with('#') || line.starts_with("ncbi_gene_id") {
+                continue;
+            }
+            let cols: Vec<&str> = line.trim().split('\t').collect();
+            let gene_id = ontology.add_gene(cols[1], cols[0])?;
+            let term_id = HpoTermId::try_from(cols[2])?;
+            ontology.link_gene_term(term_id, gene_id)?;
+
+            ontology
+                .gene_mut(&gene_id)
+                .expect("Cannot find gene {gene_id}")
+                .add_term(term_id);
+        }
+        Ok(())
+    }
+}
+
 /// Module to parse HPO - `Gene` associations from `phenotype_to_genes.txt` file
 pub(crate) mod phenotype_to_genes {
     use crate::parser::Path;
@@ -134,6 +169,18 @@ pub(crate) fn load_from_standard_files<P: AsRef<Path>>(
 ) -> HpoResult<()> {
     hp_obo::read_obo_file(obo_file, ontology)?;
     phenotype_to_genes::parse(gene_file, ontology)?;
+    phenotype_hpoa::parse(disease_file, ontology)?;
+    Ok(())
+}
+
+pub(crate) fn load_from_standard_no_transitive_genes<P: AsRef<Path>>(
+    obo_file: P,
+    gene_file: P,
+    disease_file: P,
+    ontology: &mut Ontology,
+) -> HpoResult<()> {
+    hp_obo::read_obo_file(obo_file, ontology)?;
+    genes_to_phenotype::parse(gene_file, ontology)?;
     phenotype_hpoa::parse(disease_file, ontology)?;
     Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -161,7 +161,7 @@ pub(crate) mod phenotype_hpoa {
     }
 }
 
-pub(crate) fn load_from_standard_files<P: AsRef<Path>>(
+pub(crate) fn load_from_jax_files_with_transivitve_genes<P: AsRef<Path>>(
     obo_file: P,
     gene_file: P,
     disease_file: P,
@@ -173,7 +173,7 @@ pub(crate) fn load_from_standard_files<P: AsRef<Path>>(
     Ok(())
 }
 
-pub(crate) fn load_from_standard_no_transitive_genes<P: AsRef<Path>>(
+pub(crate) fn load_from_jax_files<P: AsRef<Path>>(
     obo_file: P,
     gene_file: P,
     disease_file: P,


### PR DESCRIPTION
Fixes #44 

Gene - Term associations will not be transitive on the `Gene` annotation anymore, only direct terms are linked.

However, `HpoTerm`s will still contain annotations of all genes, also inherited from their children