### PR TITLE
Version bump to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [0.9.0] - 2024-03-27
 
+### Bugfix
+
+- Fix the name of the `BMA` SimilarityCombiner.
+
+
+## [0.9.0] - 2024-03-27
+
 ### Feature
 
 - `Gene`s by default contain only direct `HpoTerm` associations, not transitive inherited ones.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hpo"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Jonas Marcello <jonas.marcello@esbme.com>"]
 description = "Human Phenotype Ontology Similarity"


### PR DESCRIPTION
Fixes wrong GroupSimilarityCombiner variable to the correct `bma` name 